### PR TITLE
Publish separate docker tags for each platform

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -13,6 +13,15 @@ jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    # prevent duplicate workflow executions for pull_request and pull_request_target
+    if: |
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event_name == 'pull_request'
+      ) || (
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event_name == 'pull_request_target'
+      )
     secrets: inherit
     with:
       working_directory: runner
@@ -22,7 +31,14 @@ jobs:
       docker_images: |
         ghcr.io/product-os/self-hosted-runners
       bake_targets: |
-        default,focal
+        jammy,
+        focal,
+        jammy-amd64,
+        focal-amd64,
+        jammy-arm64v8,
+        focal-arm64v8,
+        jammy-arm32v7,
+        focal-arm32v7
       token_scope: >-
           {
             "actions": "read",

--- a/runner/docker-bake.hcl
+++ b/runner/docker-bake.hcl
@@ -28,3 +28,45 @@ target "focal" {
     OS_CODENAME = "focal"
   }
 }
+
+target "jammy-amd64" {
+  inherits = ["jammy"]
+  platforms = [
+    "linux/amd64"
+  ]
+}
+
+target "jammy-arm64v8" {
+  inherits = ["jammy"]
+  platforms = [
+    "linux/arm64"
+  ]
+}
+
+target "jammy-arm32v7" {
+  inherits = ["jammy"]
+  platforms = [
+    "linux/arm/v7"
+  ]
+}
+
+target "focal-amd64" {
+  inherits = ["focal"]
+  platforms = [
+    "linux/amd64"
+  ]
+}
+
+target "focal-arm64v8" {
+  inherits = ["focal"]
+  platforms = [
+    "linux/arm64"
+  ]
+}
+
+target "focal-arm32v7" {
+  inherits = ["focal"]
+  platforms = [
+    "linux/arm/v7"
+  ]
+}


### PR DESCRIPTION
This is noisy and inefficient, but allows us to pull multiple platform- specific tags in one compose file without creating image name conflicts.

Change-type: minor
See: https://github.com/product-os/flowzone/pull/559