### PR TITLE
Use su to switch to github user instead of s6-setuidgid

### DIFF
--- a/runner/start-runner.sh
+++ b/runner/start-runner.sh
@@ -100,6 +100,6 @@ chown -R "github:github" /home/github
 rm -f /var/run/runner.token
 rm -f /home/github/.runner
 
-s6-setuidgid github /home/github/config.sh "${config_args[@]}"
+su - github -c "/home/github/config.sh ${config_args[*]}" 2>&1
 
-exec s6-setuidgid github /home/github/run.sh 2>&1
+exec su - github -c "/home/github/run.sh" 2>&1


### PR DESCRIPTION
s6-setuidgid does not set the target user environment so env vars like HOME still point to /root

Change-type: patch
See: https://github.com/just-containers/s6-overlay/issues/165