### PR TITLE
Replace the github home directory with a tmpfs mount in /run

### DIFF
--- a/runner/start-runner.sh
+++ b/runner/start-runner.sh
@@ -93,6 +93,7 @@ runner_token="$(echo "${payload}" | jq -r .token)"
 echo "${runner_token}" >"/var/run/runner.token"
 
 config_args=()
+config_args+=("--disableupdate")
 config_args+=("--unattended")
 config_args+=("--name" "${ACTIONS_RUNNER_NAME}")
 config_args+=("--token" "${runner_token}")

--- a/runner/start-runner.sh
+++ b/runner/start-runner.sh
@@ -105,8 +105,6 @@ config_args+=("--labels" "\"${runner_tags_str}\"")
 [[ ${ACTIONS_RUNNER_REPLACE} =~ true|True|1|yes|Yes ]] && config_args+=("--replace")
 
 # create and chown the work directory
-# if this is a path under /run and S6_READ_ONLY_ROOT=1,
-#   s6-overlay will have remounted it as tmpfs,exec already
 mkdir -p "${ACTIONS_RUNNER_WORK_DIRECTORY}"
 chown -R "github:github" "${ACTIONS_RUNNER_WORK_DIRECTORY}"
 

--- a/runner/tmpfs-exec.sh
+++ b/runner/tmpfs-exec.sh
@@ -1,7 +1,25 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+set -ae
+
+[[ $VERBOSE =~ true|True|yes|Yes|on|On|1 ]] && set -x
 
 # these tmpfs mounts need the executable bit set
 mount -o remount,rw,exec tmpfs /tmp
 mount -o remount,rw,exec tmpfs /run
+
+# create tmpfs overlays for some directories that need to be writable
+# but should not persist container restarts
+for dir in /home/github
+do
+    # create mountpoint for a new tmpfs
+    mkdir -p "${dir}.tmpfs"
+    # create the tmpfs with execute permissions
+    mount -t tmpfs -o rw,exec tmpfs "${dir}.tmpfs"
+    # copy the contents of the original directory to the tmpfs
+    cp -av "${dir}"/* "${dir}.tmpfs"
+    # bind mount the tmpfs over the original
+    mount --bind "${dir}.tmpfs" "${dir}"
+done
 
 exec /init "${@}"


### PR DESCRIPTION
This will prevent cache and config directories like .npm and .docker from writing to the container filesystem.

Change-type: minor