### PR TITLE
Halt the container if the docker daemon dies

### DIFF
--- a/runner/s6-overlay/s6-rc.d/dockerd/finish
+++ b/runner/s6-overlay/s6-rc.d/dockerd/finish
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
-
-rm -f /var/run/docker.pid
+#!/command/execlineb -S1
+if { eltest ${1} -ne 0 -a ${1} -ne 256 }
+/run/s6/basedir/bin/halt


### PR DESCRIPTION
If the docker daemon is in a restart loop, or dead, the runner is no good to us so kill the container.

Change-type: minor