### PR TITLE
Generate a github app installation key for runner registration

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -33,13 +33,3 @@ jobs:
       docker_publish_platform_tags: true
       bake_targets: |
         default,focal
-      token_scope: >-
-          {
-            "administration": "write",
-            "contents": "write",
-            "metadata": "read",
-            "organization_self_hosted_runners": "write",
-            "packages": "write",
-            "pages": "write",
-            "pull_requests": "read"
-          }

--- a/runner/docker-compose.test.yml
+++ b/runner/docker-compose.test.yml
@@ -13,7 +13,10 @@ services:
     # https://github.com/product-os/self-hosted-runners/settings/secrets/actions/COMPOSE_VARS
     # COMPOSE_VARS=$(cat .env | openssl base64 -A)
     env_file:
-      # (required) ACTIONS_RUNNER_AUTH_TOKEN with appropriate scope(s)
+      # (optional) ACTIONS_RUNNER_APP_KEY_B64 for github app with read and write access to organization self hosted runners
+      # (optional) ACTIONS_RUNNER_APP_ID for github app with read and write access to organization self hosted runners
+      # (optional) ACTIONS_RUNNER_INSTALLATION_ID for github app with read and write access to organization self hosted runners
+      # (optional) ACTIONS_RUNNER_AUTH_TOKEN with appropriate scope(s)
       # (optional) GEOIP_API_TOKEN (https://ipinfo.io/login)
       - .env
     environment:
@@ -48,19 +51,6 @@ services:
         if readlink -f /proc/1/exe | grep -q qemu; then
           echo "Skipping runner tests for emulated environments..."
           exit 0
-        fi
-
-        if [ -z "$${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
-            ACTIONS_RUNNER_AUTH_TOKEN="$${GH_TOKEN:-}"
-        fi
-
-        if [ -z "$${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
-            ACTIONS_RUNNER_AUTH_TOKEN="$${GITHUB_TOKEN:-}"
-        fi
-
-        if [ -z "$${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
-            echo "ACTIONS_RUNNER_AUTH_TOKEN is not set"
-            exit 1
         fi
 
         /start-runner.sh &
@@ -100,11 +90,15 @@ services:
           slug=enterprises
         fi
 
+        # Get a GitHub authentication token for the runner either via GitHub App or PAT
+        # and write it to /tmp/gh_token
+        /etc/s6-overlay/scripts/get-token
+
         # wait for runner to be online
         count=0
         while ! curl -fsSL \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $${ACTIONS_RUNNER_AUTH_TOKEN}" \
+          -H "Authorization: Bearer $$(</tmp/gh_token)" \
           https://api.github.com/$${slug}/$${GITHUB_ORG}/actions/runners/$${agentId} | jq -r 'select(.status == "online") | .status'; do
             if [ "$${count}" -gt 10 ]; then
               echo "Runner failed to come online"
@@ -116,8 +110,10 @@ services:
 
         response="$$(curl -fsSL \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $${ACTIONS_RUNNER_AUTH_TOKEN}" \
+          -H "Authorization: Bearer $$(</tmp/gh_token)" \
           https://api.github.com/$${slug}/$${GITHUB_ORG}/actions/runners/$${agentId})"
+
+        rm -f /tmp/gh_token
 
         # check that our custom labels have been applied
         test $$(echo $$response | jq '.labels | length') -gt 16

--- a/runner/docker-compose.test.yml
+++ b/runner/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
     # https://github.com/product-os/self-hosted-runners/settings/secrets/actions/COMPOSE_VARS
     # COMPOSE_VARS=$(cat .env | openssl base64 -A)
     env_file:
-      # (required) GH_TOKEN with appropriate scope(s)
+      # (required) ACTIONS_RUNNER_AUTH_TOKEN with appropriate scope(s)
       # (optional) GEOIP_API_TOKEN (https://ipinfo.io/login)
       - .env
     environment:
@@ -48,6 +48,19 @@ services:
         if readlink -f /proc/1/exe | grep -q qemu; then
           echo "Skipping runner tests for emulated environments..."
           exit 0
+        fi
+
+        if [ -z "$${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
+            ACTIONS_RUNNER_AUTH_TOKEN="$${GH_TOKEN:-}"
+        fi
+
+        if [ -z "$${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
+            ACTIONS_RUNNER_AUTH_TOKEN="$${GITHUB_TOKEN:-}"
+        fi
+
+        if [ -z "$${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
+            echo "ACTIONS_RUNNER_AUTH_TOKEN is not set"
+            exit 1
         fi
 
         /start-runner.sh &
@@ -91,7 +104,7 @@ services:
         count=0
         while ! curl -fsSL \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $${GH_TOKEN:-$${GITHUB_TOKEN}}" \
+          -H "Authorization: Bearer $${ACTIONS_RUNNER_AUTH_TOKEN}" \
           https://api.github.com/$${slug}/$${GITHUB_ORG}/actions/runners/$${agentId} | jq -r 'select(.status == "online") | .status'; do
             if [ "$${count}" -gt 10 ]; then
               echo "Runner failed to come online"
@@ -103,7 +116,7 @@ services:
 
         response="$$(curl -fsSL \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $${GH_TOKEN:-$${GITHUB_TOKEN}}" \
+          -H "Authorization: Bearer $${ACTIONS_RUNNER_AUTH_TOKEN}" \
           https://api.github.com/$${slug}/$${GITHUB_ORG}/actions/runners/$${agentId})"
 
         # check that our custom labels have been applied

--- a/runner/s6-overlay/scripts/get-token
+++ b/runner/s6-overlay/scripts/get-token
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Get a GitHub authentication token for the runner either via GitHub App or PAT
+# and write it to /tmp/gh_token
+
+set -euo pipefail
+
+# force debug tracing to off as we are dealing with secrets
+set +x
+
+if [ -n "${ACTIONS_RUNNER_APP_KEY_B64:-}" ]; then
+    echo "${ACTIONS_RUNNER_APP_KEY_B64}" | base64 -d >"/tmp/private.pem"
+fi
+
+if [ -f "/tmp/private.pem" ] && [ -n "${ACTIONS_RUNNER_APP_ID:-}" ] && [ -n "${ACTIONS_RUNNER_INSTALLATION_ID:-}" ]; then
+
+    echo "Requesting GitHub App installation token for app id ${ACTIONS_RUNNER_APP_ID} and installation id ${ACTIONS_RUNNER_INSTALLATION_ID}..."
+
+    # https://www.npmjs.com/package/github-app-installation-token
+    npx -y github-app-installation-token@1.2.0 \
+        --appId "${ACTIONS_RUNNER_APP_ID}" \
+        --installationId "${ACTIONS_RUNNER_INSTALLATION_ID}" \
+        --privateKeyLocation /tmp/private.pem | tail -n1 >/tmp/gh_token
+
+    # cleanup npx cache
+    rm -rf ~/.npm/_npx
+
+    # cleanup secret files
+    rm -f /tmp/private.pem
+
+elif [ -n "${ACTIONS_RUNNER_AUTH_TOKEN:-}" ]; then
+    echo "${ACTIONS_RUNNER_AUTH_TOKEN}" >/tmp/gh_token
+elif [ -n "${GH_TOKEN:-}" ]; then
+    echo "${GH_TOKEN}" >/tmp/gh_token
+elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    echo "${GITHUB_TOKEN}" >/tmp/gh_token
+else
+    echo "Missing one of ACTIONS_RUNNER_APP_ID or ACTIONS_RUNNER_INSTALLATION_ID or ACTIONS_RUNNER_APP_KEY_B64"
+    exit 1
+fi
+
+echo "Token has been written to /tmp/gh_token"

--- a/runner/s6-overlay/scripts/start-runner
+++ b/runner/s6-overlay/scripts/start-runner
@@ -77,15 +77,24 @@ if [[ -n "${GITHUB_ENTERPRISE}" ]]; then
     url="https://github.com/${slug}/${GITHUB_ENTERPRISE}"
 fi
 
-if [[ -z "${GH_TOKEN:-${GITHUB_TOKEN}}" ]]; then
-    echo "GH_TOKEN/GITHUB_TOKEN is not set"
+ACTIONS_RUNNER_AUTH_TOKEN="${ACTIONS_RUNNER_AUTH_TOKEN:-}"
+
+if [ -z "${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
+    ACTIONS_RUNNER_AUTH_TOKEN="${GH_TOKEN:-}"
+fi
+
+if [ -z "${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
+    ACTIONS_RUNNER_AUTH_TOKEN="${GITHUB_TOKEN:-}"
+fi
+
+if [ -z "${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
+    echo "ACTIONS_RUNNER_AUTH_TOKEN is not set"
     exit 1
 fi
 
-GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN}}"
-
+# https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-a-registration-token-for-an-organization
 registration_url="https://api.github.com/${slug}/${GITHUB_ORG}/actions/runners/registration-token"
-payload=$(curl_with_opts -sX POST "${registration_url}" -H "Authorization: token ${GH_TOKEN}")
+payload=$(curl_with_opts -sX POST "${registration_url}" -H "Authorization: token ${ACTIONS_RUNNER_AUTH_TOKEN}")
 runner_token="$(echo "${payload}" | jq -r .token)"
 
 # write token to file to be read during teardown

--- a/runner/s6-overlay/scripts/start-runner
+++ b/runner/s6-overlay/scripts/start-runner
@@ -77,25 +77,16 @@ if [[ -n "${GITHUB_ENTERPRISE}" ]]; then
     url="https://github.com/${slug}/${GITHUB_ENTERPRISE}"
 fi
 
-ACTIONS_RUNNER_AUTH_TOKEN="${ACTIONS_RUNNER_AUTH_TOKEN:-}"
-
-if [ -z "${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
-    ACTIONS_RUNNER_AUTH_TOKEN="${GH_TOKEN:-}"
-fi
-
-if [ -z "${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
-    ACTIONS_RUNNER_AUTH_TOKEN="${GITHUB_TOKEN:-}"
-fi
-
-if [ -z "${ACTIONS_RUNNER_AUTH_TOKEN}" ]; then
-    echo "ACTIONS_RUNNER_AUTH_TOKEN is not set"
-    exit 1
-fi
+# Get a GitHub authentication token for the runner either via GitHub App or PAT
+# and write it to /tmp/gh_token
+/etc/s6-overlay/scripts/get-token
 
 # https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#create-a-registration-token-for-an-organization
 registration_url="https://api.github.com/${slug}/${GITHUB_ORG}/actions/runners/registration-token"
-payload=$(curl_with_opts -sX POST "${registration_url}" -H "Authorization: token ${ACTIONS_RUNNER_AUTH_TOKEN}")
+payload=$(curl_with_opts -sX POST "${registration_url}" -H "Authorization: token $(</tmp/gh_token)")
 runner_token="$(echo "${payload}" | jq -r .token)"
+
+rm -f /tmp/gh_token
 
 # write token to file to be read during teardown
 echo "${runner_token}" >"/var/run/runner.token"


### PR DESCRIPTION
Optionally use a private GitHub app with read and write access to
organization self hosted runners to register.