### PR TITLE
Remove support for Ubuntu Focal images

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -52,14 +52,12 @@ jobs:
           "linux/amd64": ["self-hosted","X64"],
           "linux/arm64": ["self-hosted","ARM64"]
         }
-      bake_targets: focal,jammy,noble
+      bake_targets: jammy,noble
       jobs_timeout_minutes: 60
       # These runners will be brought online by the docker test jobs
       custom_test_matrix: >
         {
           "os": [
-            ["distro:focal","platform:linux/amd64","run_id:${{ github.run_id }}"],
-            ["distro:focal","platform:linux/arm64","run_id:${{ github.run_id }}"],
             ["distro:jammy","platform:linux/amd64","run_id:${{ github.run_id }}"],
             ["distro:jammy","platform:linux/arm64","run_id:${{ github.run_id }}"],
             ["distro:noble","platform:linux/amd64","run_id:${{ github.run_id }}"],

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -167,8 +167,7 @@ RUN eget "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-$
 
 # https://hub.docker.com/_/microsoft-dotnet-runtime-deps
 # https://mcr.microsoft.com/en-us/product/dotnet/runtime-deps/tags
-# Ubuntu 20.04 (focal)
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.36-focal AS focal
+
 # Ubuntu 22.04 (jammy)
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.12-jammy AS jammy
 # Ubuntu 24.04 (noble)
@@ -246,19 +245,6 @@ ARG PACKAGES_common="\
     vim \
     wget \
     zstd \
-    "
-
-# install dotnet dependencies for focal (Ubuntu 20.04)
-# https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#dependencies
-ARG PACKAGES_focal="\
-    ${PACKAGES_common} \
-    libc6 \
-    libgcc-s1 \
-    libgssapi-krb5-2 \
-    libicu66 \
-    libssl1.1 \
-    libstdc++6 \
-    zlib1g \
     "
 
 # install dotnet dependencies for jammy (Ubuntu 22.04)

--- a/runner/docker-bake.hcl
+++ b/runner/docker-bake.hcl
@@ -15,13 +15,6 @@ target "default" {
   }
 }
 
-target "focal" {
-  inherits = ["default"]
-  args = {
-    OS_CODENAME = "focal"
-  }
-}
-
 target "jammy" {
   inherits = ["default"]
   args = {


### PR DESCRIPTION
GitHub is removing support for Ubuntu 20.04 on April 1, 2025 so we will follow suit.

Change-type: minor