### PR TITLE
Use free hosted runners

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -49,8 +49,8 @@ jobs:
         ghcr.io/product-os/self-hosted-runners
       docker_runs_on: >
         {
-          "linux/amd64": ["Linux-32-core"],
-          "linux/arm64": ["Linux-32-core-arm"]
+          "linux/amd64": ["ubuntu-24.04"],
+          "linux/arm64": ["ubuntu-24.04-arm"]
         }
       bake_targets: jammy,noble
       jobs_timeout_minutes: 60


### PR DESCRIPTION
These will be slower, but free is good and avoids depending on our self-hosted fleet in case of an outage if we need to build a new image.

See https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Github-Actions-are-not-picked-up-by-self-hosted-github-runners-68