### PR TITLE
Update from NodeJS 22.x to 24.x

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -155,7 +155,7 @@ RUN eget nabeken/go-github-apps \
 FROM eget-build AS node
 
 # renovate: datasource=node depName=node
-ARG NODE_VERSION=22.18.0
+ARG NODE_VERSION=24.5.0
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
NodeJS v24 is the current LTS and is going to
start becomming required by actions.

e.g. https://github.com/actions/checkout/releases/tag/v5.0.0

Change-type: minor